### PR TITLE
Ensure that partial body packet reads will resume.

### DIFF
--- a/ccnx/transport/transport_rta/connectors/connector_Forwarder_Metis.c
+++ b/ccnx/transport/transport_rta/connectors/connector_Forwarder_Metis.c
@@ -1137,6 +1137,8 @@ _readPacket(FwdMetisState *fwd_state)
     // are we still reading the header?
     if (fwd_state->nextMessage.remainingReadLength > 0) {
         returnCode = _readPacketHeader(fwd_state);
+    } else {
+        returnCode = ReadReturnCode_Finished;
     }
 
     // After reading the header, it may be possible to read the body too


### PR DESCRIPTION
Proposed fix for issue #8 

The value of returnCode prevents subsequent invocations of _readPacket
from calling _readPacketBody when the packet header has already been
read.  Override the returnCode value when we see that the header has
been read.

I'm not 100% confident that this is the right fix, but it does solve my immediate problems.